### PR TITLE
Restore functionality of hiding disclaimer

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -550,7 +550,7 @@
 
         // Remove disclaimer
         if (IsSettingEnabled('removeDisclaimer')) {
-            $('#ctl00_divContentMain div.span-17 div.Note.Disclaimer').remove();
+            $('#divContentMain div.span-17 div.Note.Disclaimer').remove();
         }
 
         // Collapse download links


### PR DESCRIPTION
Based on the [QA](http://project-gc.com/qa/?qa=12329/the-greasemonkey-script-cannot-remove-disclaimer), restore functionality of disclaimer hiding after the change in HTML of the cache page.