### PR TITLE
Apply the domain filter only on the profile page

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -65,23 +65,10 @@
             Page_Map();
         } else if(path.match(/^\/seek\/gallery\.aspx.*/) !== null) {
             Page_Gallery();
+        } else if(path.match(/^\/profile\/.*/) !== null) {
+            Page_Profile();
         }
 
-    }
-
-    function CommonTweaks() {
-        // Override gc.com function on alerting for external links to not alert for Project-GC URLs
-        var gcAlertOverride = document.createElement('script');
-        gcAlertOverride.type = "text/javascript";
-        gcAlertOverride.innerHTML = `(function() {
-                var _old_isGeocachingDomain = isGeocachingDomain;
-                isGeocachingDomain = function(url) {
-                    return (_old_isGeocachingDomain.apply(this, arguments)
-                        || url == "project-gc.com"
-                        || url == "www.project-gc.com");
-                };
-            })();`;
-        document.getElementsByTagName('head')[0].appendChild(gcAlertOverride);
     }
 
     function GetSettingsItems() {
@@ -341,7 +328,6 @@
                 subscription = Boolean(result.data.subscription);
 
                 BuildPGCUserMenu();
-                CommonTweaks();
                 Router();
             },
             onerror: function(response) {
@@ -521,6 +507,21 @@
                 return false;
             }
         });
+    }
+
+    function Page_Profile() {
+        // Override gc.com function on alerting for external links to not alert for Project-GC URLs
+        var gcAlertOverride = document.createElement('script');
+        gcAlertOverride.type = "text/javascript";
+        gcAlertOverride.innerHTML = `(function() {
+                var _old_isGeocachingDomain = isGeocachingDomain;
+                isGeocachingDomain = function(url) {
+                    return (_old_isGeocachingDomain.apply(this, arguments)
+                        || url == "project-gc.com"
+                        || url == "www.project-gc.com");
+                };
+            })();`;
+        document.getElementsByTagName('head')[0].appendChild(gcAlertOverride);
     }
 
     /**


### PR DESCRIPTION
Apply the new domain filter only for the profile page(s) to make sure it does not error out on the other pages (once more #35).