### PR TITLE
Add a link to event statistics, if we list the will-attend count

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -615,6 +615,7 @@
                                 }
                                 html += '</ul>';
                                 html += '<span style="display: block; text-align: right; padding-right: 10px;"><small>' + geocacheLogsPerCountry['willAttend'].length + ' unique countries</small></span>';
+                                html += '<span style="display: block; text-align: right; padding-right: 10px;"><small><a href="https://project-gc.com/Tools/EventStatistics?gccode=' + encodeURIComponent(gccode) + '">Event statistics</a></small></span>';
                             }
 
                             if(typeof(geocacheLogsPerCountry['found']) != 'undefined' && geocacheLogsPerCountry['found'].length > 0) {


### PR DESCRIPTION
This is just a cosmetic issue to add a link and promote the event statistics functionality. It creates a link, if there is a Will attend count by country.

There might be better place to position/format the link so improvements welcomed.

Preview:

![image](https://user-images.githubusercontent.com/2694489/30281352-6eedf9b2-9712-11e7-9daa-9a5a9492804d.png)
