### PR TITLE
Option for FP% with decimals

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -649,7 +649,7 @@
                                 "border-bottom-right-radius": "0"
                             });
                         }
-                        
+
                         // Add elevation (Metres above mean sea level = mamsl)
                         if (IsSettingEnabled('addElevation')) {
                             var formattedElevation = FormatDistance(cacheData.elevation),

--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -136,10 +136,6 @@
                 title: 'Add FP from PGC',
                 default: true
             },
-            addPgcFppDec: {
-                title: 'Add FP from PGC but FP% has two decimals',
-                default: false
-            },
             showWeekday: {
                 title: 'Show weekday of the place date',
                 default: true
@@ -642,24 +638,12 @@
                             $('#ctl00_ContentBody_mcd1 span.message__owner').before('<a href="' + pgcUrl + 'ProfileStats/' + encodeURIComponent(cacheOwner) + '"><img src="' + externalLinkIcon + '" title="PGC Profile Stats"></a>');
                         }
 
-                        // Add FP/FP%/FPW below the current FP
+                        // Add FP/FP%/FPW below the current FP + mouseover for FP% and FPW with decimals
                         if (IsSettingEnabled('addPgcFp')) {
-                            fp = parseInt(+cacheData.favorite_points, 10),
-                                fpp = parseInt(+cacheData.favorite_points_pct, 10),
-                                fpw = parseInt(+cacheData.favorite_points_wilson, 10);
-                            $('#uxFavContainerLink').append('<p style="text-align: center; background-color: #f0edeb;border-bottom-left-radius: 5px;border-bottom-right-radius:5px;">PGC: ' + fp + ' FP, ' + fpp + '%, ' + fpw + 'W</p>');
-                            $('.favorite-container').css({
-                                "border-bottom-left-radius": "0",
-                                "border-bottom-right-radius": "0"
-                            });
-                        }
-                        
-                        // Add FP/FP%/FPW below the current FP but FP% has two decimals to match main site
-                        if (IsSettingEnabled('addPgcFppDec')) {
-                            fp = parseInt(+cacheData.favorite_points, 10),
-                                fpp = parseFloat(+cacheData.favorite_points_pct).toFixed(2),
-                                fpw = parseInt(+cacheData.favorite_points_wilson, 10);
-                            $('#uxFavContainerLink').append('<p style="text-align: center; background-color: #f0edeb;border-bottom-left-radius: 5px;border-bottom-right-radius:5px;">PGC: ' + fp + ' FP, ' + fpp + '%, ' + fpw + 'W</p>');
+                            fp = (+cacheData.favorite_points),
+                                fpp = (+cacheData.favorite_points_pct),
+                                fpw = (+cacheData.favorite_points_wilson);
+                            $('#uxFavContainerLink').append('<p title= "' + parseFloat(fpp) + '%, ' + parseFloat(fpw) + 'W" style="text-align: center; background-color: #f0edeb;border-bottom-left-radius: 5px;border-bottom-right-radius:5px;">PGC: ' + parseInt(fp) + ' FP, ' + Math.round(fpp) + '%, ' + Math.round(fpw) + 'W</p>');
                             $('.favorite-container').css({
                                 "border-bottom-left-radius": "0",
                                 "border-bottom-right-radius": "0"

--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -136,6 +136,10 @@
                 title: 'Add FP from PGC',
                 default: true
             },
+            addPgcFppDec: {
+                title: 'Add FP from PGC but FP% has two decimals',
+                default: false
+            },
             showWeekday: {
                 title: 'Show weekday of the place date',
                 default: true
@@ -649,7 +653,19 @@
                                 "border-bottom-right-radius": "0"
                             });
                         }
-
+                        
+                        // Add FP/FP%/FPW below the current FP but FP% has two decimals to match main site
+                        if (IsSettingEnabled('addPgcFppDec')) {
+                            fp = parseInt(+cacheData.favorite_points, 10),
+                                fpp = parseFloat(+cacheData.favorite_points_pct).toFixed(2),
+                                fpw = parseInt(+cacheData.favorite_points_wilson, 10);
+                            $('#uxFavContainerLink').append('<p style="text-align: center; background-color: #f0edeb;border-bottom-left-radius: 5px;border-bottom-right-radius:5px;">PGC: ' + fp + ' FP, ' + fpp + '%, ' + fpw + 'W</p>');
+                            $('.favorite-container').css({
+                                "border-bottom-left-radius": "0",
+                                "border-bottom-right-radius": "0"
+                            });
+                        }
+                        
                         // Add elevation (Metres above mean sea level = mamsl)
                         if (IsSettingEnabled('addElevation')) {
                             var formattedElevation = FormatDistance(cacheData.elevation),


### PR DESCRIPTION
I don't know if I'm missing any downside with parseFloat that I didn't find on my googling, I technically don't know what I'm doing here but this seems to work as far as I've tried it at least. :)

The idea is that users can chose if they want FP% to show as the script does now, or select the option for showing it with two decimals as it's done on PGCs top list to solve the issue with the script dropping the decimals instead of rounding them. Default is false for the FP%-with-decimals-option and using both at the same time looks ugly. This could probably be done in a better/smoother way, but it's my first try.