### PR TITLE
Fix: exclude Help Center

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -18,7 +18,8 @@
 // @match           http://www.geocaching.com/*
 // @match           https://www.geocaching.com/*
 // @exclude         https://www.geocaching.com/profile/profilecontent.html
-// @version         2.4.6
+// @exclude         https://www.geocaching.com/help/*
+// @version         2.4.7
 // @require         http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js
 // @require         https://greasyfork.org/scripts/383527-wait-for-key-elements/code/Wait_for_key_elements.js?version=701631
 // @require         https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js


### PR DESCRIPTION
This fixes #152 by excluding `https://www.geocaching.com/help/*` from the script.