### PR TITLE
Copyable link override GClh's copy to clipboard

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -854,7 +854,7 @@
         // Make it easier to copy the gccode
         if (IsSettingEnabled('makeCopyFriendly')) {
             $('#ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoLinkPanel').
-            html('<div style="margin-right: 15px; margin-bottom: 10px;"><p id="ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode" style="font-size: 125%; margin-bottom: 0">' + gccode + '</p>' +
+            html('<div style="margin-right: 15px; margin-bottom: 10px;"><p style="font-size: 125%; margin-bottom: 0"><span id="ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode">' + gccode + '</span></p>' +
                 '<input size="25" type="text" value="https://coord.info/' + encodeURIComponent(gccode) + '" onclick="this.setSelectionRange(0, this.value.length);"></div>');
             $('#ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoLinkPanel').css('font-weight', 'inherit').css('margin-right', '27px');
             $('#ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoLinkPanel div input').css('padding', '0');

--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -19,7 +19,7 @@
 // @match           https://www.geocaching.com/*
 // @exclude         https://www.geocaching.com/profile/profilecontent.html
 // @exclude         https://www.geocaching.com/help/*
-// @version         2.4.10
+// @version         2.4.11
 // @require         http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js
 // @require         https://greasyfork.org/scripts/383527-wait-for-key-elements/code/Wait_for_key_elements.js?version=701631
 // @require         https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js


### PR DESCRIPTION
Hello,
the GClh has a function, which adds a button to copy the GC code to clipboard. But this scrip overrides the change directly.
Without PGC (with GClh):
![grafik](https://github.com/2Abendsegler/GClh/assets/50927164/058e8983-1d76-44a5-be0a-aeae74707098)
With both:
![grafik](https://github.com/2Abendsegler/GClh/assets/50927164/c818cc89-f49c-402c-abd3-2b9265d7c3d2)

Now we try to fix it, but it will be more easy, when we make changes on both scrips.
With this PR and the changes we did on the GClh (https://github.com/2Abendsegler/GClh/pull/2426) both features are working, if both scrips are running.

Our related Issue: https://github.com/2Abendsegler/GClh/issues/2420 (in German language) ´